### PR TITLE
change the time zone

### DIFF
--- a/src/components/EventsList.jsx
+++ b/src/components/EventsList.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
+import { dateTimeFormatter } from '/src/utils/intlUtils';
 
 function EventsList() {
   const [events, setEvents] = useState([]);
@@ -11,7 +12,9 @@ function EventsList() {
   useEffect(() => {
     const fetchEvents = async () => {
       try {
-        const response = await axios.get(`${import.meta.env.VITE_BASE_URL}/api/events/all-events`);
+        const response = await axios.get(
+          `${import.meta.env.VITE_BASE_URL}/api/events/all-events`,
+        );
         setEvents(response.data.events);
       } catch (err) {
         console.error('Error fetching events:', err);
@@ -38,7 +41,9 @@ function EventsList() {
         maxWidth: '95%', // Allow the container to use more of the screen
       }}
     >
-      <h2 className="text-3xl font-bold text-center text-white mb-4">Upcoming Events</h2>
+      <h2 className="text-3xl font-bold text-center text-white mb-4">
+        Upcoming Events
+      </h2>
       <div
         className="events-list flex flex-col gap-3 mx-auto"
         style={{
@@ -66,7 +71,8 @@ function EventsList() {
                 {event.title}
               </h3>
               <p className="text-gray-500 text-xs mt-1">
-                {new Date(event.event_date).toLocaleDateString()}
+                {!isNaN(Date.parse(event.event_date)) &&
+                  dateTimeFormatter.format(new Date(event.event_date))}
               </p>
             </div>
 

--- a/src/utils/intlUtils.js
+++ b/src/utils/intlUtils.js
@@ -1,0 +1,8 @@
+const dTFOptions = {
+	weekday: "long",
+	year: "numeric",
+	month: "long",
+	day: "numeric",
+	timeZone: "UTC",
+};
+export const dateTimeFormatter = new Intl.DateTimeFormat("en-US", dTFOptions);


### PR DESCRIPTION
Since the event date from the backend is in UTC, the frontend should align with it to avoid discrepancies caused by the browser's local time zone.